### PR TITLE
Add image template for systemd-debian:sid

### DIFF
--- a/systemd/debian/sid/Dockerfile
+++ b/systemd/debian/sid/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:sid
+
+ENV container docker
+ENV LC_ALL C
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+    && apt-get install -y systemd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+    /etc/systemd/system/*.wants/* \
+    /lib/systemd/system/local-fs.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl* \
+    /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
+    /lib/systemd/system/systemd-update-utmp*
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/lib/systemd/systemd"]

--- a/systemd/debian/sid/README.md
+++ b/systemd/debian/sid/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
Many people need to test systemd stuff on the development version of
Debian before it is released, so it is good to have it available as well.