### PR TITLE
Ensure /sbin/init is a symlink to systemd

### DIFF
--- a/systemd/debian/10.Dockerfile
+++ b/systemd/debian/10.Dockerfile
@@ -5,7 +5,7 @@ ENV LC_ALL C
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
-    && apt-get install -y systemd \
+    && apt-get install -y systemd systemd-sysv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/systemd/debian/11.Dockerfile
+++ b/systemd/debian/11.Dockerfile
@@ -5,7 +5,7 @@ ENV LC_ALL C
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
-    && apt-get install -y systemd \
+    && apt-get install -y systemd systemd-sysv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/systemd/debian/8.Dockerfile
+++ b/systemd/debian/8.Dockerfile
@@ -5,7 +5,7 @@ ENV LC_ALL C
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
-    && apt-get install -y systemd \
+    && apt-get install -y systemd systemd-sysv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/systemd/debian/9.Dockerfile
+++ b/systemd/debian/9.Dockerfile
@@ -5,7 +5,7 @@ ENV LC_ALL C
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
-    && apt-get install -y systemd \
+    && apt-get install -y systemd systemd-sysv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/systemd/ubuntu/16.04.Dockerfile
+++ b/systemd/ubuntu/16.04.Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list
 
 RUN apt-get update \
-    && apt-get install -y systemd \
+    && apt-get install -y systemd systemd-sysv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/systemd/ubuntu/18.04.Dockerfile
+++ b/systemd/ubuntu/18.04.Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list
 
 RUN apt-get update \
-    && apt-get install -y systemd \
+    && apt-get install -y systemd systemd-sysv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/systemd/ubuntu/20.04.Dockerfile
+++ b/systemd/ubuntu/20.04.Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list
 
 RUN apt-get update \
-    && apt-get install -y systemd \
+    && apt-get install -y systemd systemd-sysv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
The systemd-sysv package does not get installed along with systemd on
some versions of Debian (9, 11) and Ubuntu (20.04). This simply brings
those images in line with the others, and ensures `/sbin/init` is a
symlink to systemd.

Looking at `/sbin/init` and where it symlinks to is one way to determine
what init-system is used. Ansible's service_mgr module for example does
just that:

https://github.com/ansible/ansible/blob/3acd8f6f7f61b72a42a017060c3a718bbbeaf854/lib/ansible/module_utils/facts/system/service_mgr.py#L61